### PR TITLE
Added ability to pause a whole Sequence from their callback including other callbacks

### DIFF
--- a/_DOTween.Assembly/DOTween/Core/TweenManager.cs
+++ b/_DOTween.Assembly/DOTween/Core/TweenManager.cs
@@ -713,6 +713,7 @@ namespace DG.Tweening.Core
         {
             if (t.isPlaying) {
                 t.isPlaying = false;
+                t.isPaused = true;
                 if (t.onPause != null) Tween.OnTweenCallback(t.onPause);
                 return true;
             }
@@ -724,6 +725,7 @@ namespace DG.Tweening.Core
         {
             if (!t.isPlaying && (!t.isBackwards && !t.isComplete || t.isBackwards && (t.completedLoops > 0 || t.position > 0))) {
                 t.isPlaying = true;
+                t.isPaused = false;
                 if (t.playedOnce && t.delayComplete && t.onPlay != null) {
                     // Don't call in case there's a delay to run or if it hasn't started because onStart routine will call it
                     Tween.OnTweenCallback(t.onPlay);
@@ -740,6 +742,7 @@ namespace DG.Tweening.Core
                 ManageOnRewindCallbackWhenAlreadyRewinded(t, true);
                 t.isBackwards = true;
                 t.isPlaying = false;
+                t.isPaused = false;
                 return false;
             }
             if (!t.isBackwards) {
@@ -755,6 +758,7 @@ namespace DG.Tweening.Core
             if (t.isComplete) {
                 t.isBackwards = false;
                 t.isPlaying = false;
+                t.isPaused = false;
                 return false;
             }
             if (t.isBackwards) {
@@ -772,6 +776,7 @@ namespace DG.Tweening.Core
             if (changeDelayTo >= 0) t.delay = changeDelayTo;
             Rewind(t, includeDelay);
             t.isPlaying = true;
+            t.isPaused = false;
             if (wasPaused && t.playedOnce && t.delayComplete && t.onPlay != null) {
                 // Don't call in case there's a delay to run or if it hasn't started because onStart routine will call it
                 Tween.OnTweenCallback(t.onPlay);
@@ -783,6 +788,7 @@ namespace DG.Tweening.Core
         {
             bool wasPlaying = t.isPlaying; // Manage onPause from this method because DoGoto won't detect it
             t.isPlaying = false;
+            t.isPaused = false;
             bool rewinded = false;
             if (t.delay > 0) {
                 if (includeDelay) {

--- a/_DOTween.Assembly/DOTween/Sequence.cs
+++ b/_DOTween.Assembly/DOTween/Sequence.cs
@@ -308,8 +308,8 @@ namespace DG.Tweening
                     if (sequentiable.tweenType == TweenType.Callback) {
                         if (updateMode == UpdateMode.Update) {
 //                            Debug.Log("<color=#FFEC03>FORWARD Callback > " + s.id + " - s.isBackwards: " + s.isBackwards + ", useInverse/prevInverse: " + useInverse + "/" + prevPosIsInverse + " - " + fromPos + " > " + toPos + "</color>");
-                            bool fire = !s.isBackwards && !useInverse && !prevPosIsInverse
-                                || s.isBackwards && useInverse && !prevPosIsInverse;
+                            bool fire = ((!s.isBackwards && !useInverse && !prevPosIsInverse)
+                                || (s.isBackwards && useInverse && !prevPosIsInverse)) && !s.isPaused;
                             if (fire) OnTweenCallback(sequentiable.onStart);
                         }
                     } else {

--- a/_DOTween.Assembly/DOTween/Tween.cs
+++ b/_DOTween.Assembly/DOTween/Tween.cs
@@ -110,6 +110,8 @@ namespace DG.Tweening
         
         internal int miscInt = -1; // Used by some plugins to store data (currently only by Paths to store current waypoint index)
 
+        internal bool isPaused;
+
         #region Abstracts + Overrideables
 
         // Doesn't reset active state, activeId and despawned, since those are only touched by TweenManager
@@ -139,7 +141,7 @@ namespace DG.Tweening
             specialStartupMode = SpecialStartupMode.None;
             creationLocked = startupDone = playedOnce = false;
             position = fullDuration = completedLoops = 0;
-            isPlaying = isComplete = false;
+            isPlaying = isPaused = isComplete = false;
             elapsedDelay = 0;
             delayComplete = true;
 


### PR DESCRIPTION
Hey there!

I have added ability to pause a whole ```Sequence``` from their callback including other callbacks. It is very often situation when I have some ```Sequence``` which has several callbacks one by one (added from several ```if``` conditions) and sometimes it is very useful to have an ability to pause ```Sequence``` execution after some callback while delaying rest of callbacks.

Let me show you an example:

```csharp
var sequence = DOTween.Sequence();

sequence.AppendSomething();
sequence.AppendCallback(() => { if (condition) sequence.Pause()});

if(someExpression) sequence.AppendCallback(() => Action1());
```

So as you can see I'm trying to pause a ```sequence``` from one of appended callbacks but ***anyway*** I can see that next callback will be fired.