### PR TITLE
Debug mode suggestion: Capture stack trace when creating a new tween.

### DIFF
--- a/_DOTween.Assembly/DOTween/Core/TweenManager.cs
+++ b/_DOTween.Assembly/DOTween/Core/TweenManager.cs
@@ -1087,6 +1087,8 @@ namespace DG.Tweening.Core
         // Adds the given tween to the active tweens list (updateType is always Normal, but can be changed by SetUpdateType)
         static void AddActiveTween(Tween t)
         {
+            t.stackTrace = Environment.StackTrace;
+
             if (_requiresActiveReorganization) ReorganizeActiveTweens();
 
             // Safety check (IndexOutOfRangeException)

--- a/_DOTween.Assembly/DOTween/Tween.cs
+++ b/_DOTween.Assembly/DOTween/Tween.cs
@@ -16,6 +16,8 @@ namespace DG.Tweening
     /// </summary>
     public abstract class Tween : ABSSequentiable
     {
+        public string stackTrace = null;
+
         // OPTIONS ///////////////////////////////////////////////////
 
         // Modifiable at runtime

--- a/_DOTween.Assembly/DOTween/Tweener.cs
+++ b/_DOTween.Assembly/DOTween/Tweener.cs
@@ -141,7 +141,8 @@ namespace DG.Tweening
                     } catch (Exception e) {
                         if (Debugger.ShouldLogSafeModeCapturedError()) {
                             Debugger.LogSafeModeCapturedError(string.Format(
-                                "Tween startup failed (NULL target/property - {0}): the tween will now be killed ► {1}", e.TargetSite, e.Message
+                                "Tween startup failed (NULL target/property - {0}): the tween will now be killed ► {1}" +
+                                "\n\nstackTrace:\n{2}", e.TargetSite, e.Message, t.stackTrace
                             ), t);
                         }
                         DOTween.safeModeReport.Add(SafeModeReport.SafeModeReportType.StartupFailure);


### PR DESCRIPTION
Sometimes we experience this kind of DOTween errors:

```
DOTWEEN ► DEBUG MODE INFO ► [tween target: null]
Tween startup failed (NULL target/property - ): the tween will now be killed ► The object of type 'CanvasGroup' has been destroyed but you are still trying to access it.
Your script should either check if it is null or you should not destroy the object.
UnityEngine.Debug:LogWarning (object)
DG.Tweening.Core.Debugger:LogSafeModeCapturedError (object,DG.Tweening.Tween) (at Assets/ThirdParty/DOTween/Core/Debugger.cs:61)
DG.Tweening.Tweener:DoStartup<single, single, DG.Tweening.Plugins.Options.FloatOptions> (DG.Tweening.Core.TweenerCore`3<single, single, DG.Tweening.Plugins.Options.FloatOptions>) (at Assets/ThirdParty/DOTween/Tweener.cs:143)
DG.Tweening.Core.TweenerCore`3<single, single, DG.Tweening.Plugins.Options.FloatOptions>:Startup () (at Assets/ThirdParty/DOTween/Core/TweenerCore.cs:250)
DG.Tweening.Core.TweenManager:Update (DG.Tweening.Tween,single,single,bool) (at Assets/ThirdParty/DOTween/Core/TweenManager.cs:536)
DG.Tweening.Core.TweenManager:Update (DG.Tweening.UpdateType,single,single) (at Assets/ThirdParty/DOTween/Core/TweenManager.cs:420)
DG.Tweening.Core.DOTweenComponent:Update () (at Assets/ThirdParty/DOTween/Core/DOTweenComponent.cs:75)
```

The error is caused by mishandling created tweens on our side. This error message isn't very helpful, it doesn't show enough info to quickly find the cause of the error and fix it. I'd like to have a configurable debug option to capture stack traces of every created (and pooled) tweens. This pull request show a rough idea of doing that.

After applying this PoC pull request, the error message includes the actual filename and line number where the tween was created. In this case it is BaseBattleUI.cs:77. Now I'm able to add the code to properly dispose of the created tween (for example, add `OnKill` or kill it in `OnDisable`).

```
DOTWEEN ► DEBUG MODE INFO ► [tween target: null]
Tween startup failed (NULL target/property - ): the tween will now be killed ► The object of type 'CanvasGroup' has been destroyed but you are still trying to access it.
Your script should either check if it is null or you should not destroy the object.

stackTrace:  at System.Environment.get_StackTrace () [0x00000] in <1f66344f2f89470293d8b67d71308c07>:0 
  at DG.Tweening.Core.TweenManager.AddActiveTween (DG.Tweening.Tween t) [0x00000] in <projectroot>\Assets\ThirdParty\DOTween\Core\TweenManager.cs:1093 
  at DG.Tweening.Core.TweenManager.GetTweener[T1,T2,TPlugOptions] () [0x0007b] in <projectroot>\Assets\ThirdParty\DOTween\Core\TweenManager.cs:89 
  at DG.Tweening.DOTween.ApplyTo[T1,T2,TPlugOptions] (DG.Tweening.Core.DOGetter`1[T] getter, DG.Tweening.Core.DOSetter`1[T] setter, T2 endValue, System.Single duration, DG.Tweening.Plugins.Core.ABSTweenPlugin`3[T1,T2,TPlugOptions] plugin) [0x00005] in <projectroot>\Assets\ThirdParty\DOTween\DOTween.cs:1139 
  at DG.Tweening.DOTween.To (DG.Tweening.Core.DOGetter`1[T] getter, DG.Tweening.Core.DOSetter`1[T] setter, System.Single endValue, System.Single duration) [0x00000] in <projectroot>\Assets\ThirdParty\DOTween\DOTween.cs:361 
  at DG.Tweening.DOTweenModuleUI.DOFade (UnityEngine.CanvasGroup target, System.Single endValue, System.Single duration) [0x0000d] in <projectroot>\Assets\ThirdParty\DOTween\Modules\DOTweenModuleUI.cs:31 
  at BaseBattleUI.Hide () [0x00022] in <projectroot>\Assets\Scripts\Battle\Fx\BaseBattleUI.cs:77 
  at BaseBattleUI.OnBattleEnded () [0x0001e] in <projectroot>\Assets\Scripts\Battle\Fx\BaseBattleUI.cs:60 
  at GameController.RaiseBattleEnded () [0x00015] in <projectroot>\Assets\Scripts\Battle\Managers\GameController.cs:705 
  at GameController.ChangeBattleState (GameController+BattleStateEnum newState) [0x00010] in <projectroot>\Assets\Scripts\Battle\Managers\GameController.cs:888 
  at MetroController.CheckWinCondition () [0x0001d] in <projectroot>\Assets\Scripts\Battle\Managers\GameMode\MetroController.cs:76 
  at MetroController.OnFixedUpdate () [0x00000] in <projectroot>\Assets\Scripts\Battle\Managers\GameMode\MetroController.cs:58 
  at GameController.FixedUpdate () [0x00054] in <projectroot>\Assets\Scripts\Battle\Managers\GameController.cs:695 
UnityEngine.Debug:LogWarning (object)
DG.Tweening.Core.Debugger:LogSafeModeCapturedError (object,DG.Tweening.Tween) (at Assets/ThirdParty/DOTween/Core/Debugger.cs:61)
DG.Tweening.Tweener:DoStartup<single, single, DG.Tweening.Plugins.Options.FloatOptions> (DG.Tweening.Core.TweenerCore`3<single, single, DG.Tweening.Plugins.Options.FloatOptions>) (at Assets/ThirdParty/DOTween/Tweener.cs:143)
DG.Tweening.Core.TweenerCore`3<single, single, DG.Tweening.Plugins.Options.FloatOptions>:Startup () (at Assets/ThirdParty/DOTween/Core/TweenerCore.cs:250)
DG.Tweening.Core.TweenManager:Update (DG.Tweening.Tween,single,single,bool) (at Assets/ThirdParty/DOTween/Core/TweenManager.cs:536)
DG.Tweening.Core.TweenManager:Update (DG.Tweening.UpdateType,single,single) (at Assets/ThirdParty/DOTween/Core/TweenManager.cs:420)
DG.Tweening.Core.DOTweenComponent:Update () (at Assets/ThirdParty/DOTween/Core/DOTweenComponent.cs:75)
```