### PR TITLE
add DOTWEEN_ASMDEF global marco

### DIFF
--- a/_DOTween.Assembly/DOTweenEditor/ASMDEFManager.cs
+++ b/_DOTween.Assembly/DOTweenEditor/ASMDEFManager.cs
@@ -122,6 +122,9 @@ namespace DG.DOTweenEditor
                 if (!hasDOTweenTimelineASMDEF) CreateASMDEF(ASMDEFType.DOTweenTimeline);
                 if (!hasDOTweenTimelineEditorASMDEF) CreateASMDEF(ASMDEFType.DOTweenTimelineEditor);
             }
+
+            if (!EditorUtils.HasGlobalDefine(DOTweenDefines.GlobalDefine_DOTween_ASDMEF))
+                EditorUtils.AddGlobalDefine(DOTweenDefines.GlobalDefine_DOTween_ASDMEF);
         }
 
         public static void RemoveAllASMDEF()
@@ -134,6 +137,7 @@ namespace DG.DOTweenEditor
             if (hasProEditorASMDEF) RemoveASMDEF(ASMDEFType.DOTweenProEditor);
             if (hasDOTweenTimelineASMDEF) RemoveASMDEF(ASMDEFType.DOTweenTimeline);
             if (hasDOTweenTimelineEditorASMDEF) RemoveASMDEF(ASMDEFType.DOTweenTimelineEditor);
+            EditorUtils.RemoveGlobalDefine(DOTweenDefines.GlobalDefine_DOTween_ASDMEF);
         }
 
         #endregion

--- a/_DOTween.Assembly/DOTweenEditor/DOTweenDefines.cs
+++ b/_DOTween.Assembly/DOTweenEditor/DOTweenDefines.cs
@@ -1,6 +1,6 @@
 ﻿// Author: Daniele Giardini - http://www.demigiant.com
 // Created: 2014/09/30 11:59
-// 
+//
 // License Copyright (c) Daniele Giardini.
 // This work is subject to the terms at http://dotween.demigiant.com/license.php
 
@@ -17,6 +17,7 @@ namespace DG.DOTweenEditor
     static class DOTweenDefines
     {
         public const string GlobalDefine_DOTween = "DOTWEEN";
+        public const string GlobalDefine_DOTween_ASDMEF = "DOTWEEN_ASMDEF";
         // Legacy (in versions older than 1.2.050)
         // Modules
         public const string GlobalDefine_Legacy_AudioModule = "DOTAUDIO";
@@ -34,6 +35,7 @@ namespace DG.DOTweenEditor
         public static void RemoveAllDefines()
         {
             EditorUtils.RemoveGlobalDefine(GlobalDefine_DOTween);
+            EditorUtils.RemoveGlobalDefine(GlobalDefine_DOTween_ASDMEF);
         }
 
         // Removes all legacy defines


### PR DESCRIPTION
This PR is created to resolve the dependency issue when DOTween is an optional dependence of a package.

Because [DOTween is not a package](https://github.com/Demigiant/dotween/issues/251), a standard package can not directly use DOTween.

A common approach for a standard package to optionally depend on DOTween is:

1.  in ASMDEF of the the package itself - `Assembly References`, add `DOTween.dll`

    ![image](https://github.com/Demigiant/dotween/assets/6391063/7aa0a182-de28-4016-be76-262314ff1816)

3.  because DOTween has no `package.json`, skip the `Version Defines` here
4.  use marco `DOTWEEN` to optionally execute logic with DoTween:

    ```csharp
    #if DOTWEEN
    using DG.Tweening;
    // other logic
    #endif
    ````

Here `using DG.Tweening;` will failed when DOTween's ASMDEF has not been created yet, which requires user to manually create that.

## Propose  ##

This PR add `DOTWEEN_ASMDEF ` when user created the ASMDEF of DOTween, and a standard package can now optionally depend on DOTween with the same approach, but change:

```csharp
#if DOTWEEN
```

to 

```csharp
#if DOTWEEN_ASMDEF
```

-----------------------------

This PR is created because the #586 has been pending for two years. This PR is much much more simple than 586. Though it does not directly resolve the package problem of DOTween, but it allows DOTween to be optionally dependent by other packages right away, with much less time to review the changes I've made