### PR TITLE
Feat: forbid tasks on WebGL

### DIFF
--- a/UnityExamples.Unity5/Assets/Plugins/Demigiant/DOTween/Modules/DOTweenModuleUnityVersion.cs
+++ b/UnityExamples.Unity5/Assets/Plugins/Demigiant/DOTween/Modules/DOTweenModuleUnityVersion.cs
@@ -216,7 +216,7 @@ namespace DG.Tweening
 
         #region .NET 4.6 or Newer
 
-#if UNITY_2018_1_OR_NEWER && (NET_4_6 || NET_STANDARD_2_0)
+#if UNITY_2018_1_OR_NEWER && (NET_4_6 || NET_STANDARD_2_0) && !UNITY_WEBGL
 
         #region Async Instructions
 

--- a/UnityTests.Unity2020.3/Assets/Plugins/Demigiant/DOTween/Modules/DOTweenModuleUnityVersion.cs
+++ b/UnityTests.Unity2020.3/Assets/Plugins/Demigiant/DOTween/Modules/DOTweenModuleUnityVersion.cs
@@ -204,7 +204,7 @@ namespace DG.Tweening
 
         #region .NET 4.6 or Newer
 
-#if UNITY_2018_1_OR_NEWER && (NET_4_6 || NET_STANDARD_2_0)
+#if UNITY_2018_1_OR_NEWER && (NET_4_6 || NET_STANDARD_2_0) && !UNITY_WEBGL
 
         #region Async Instructions
 

--- a/UnityTests.Unity5.LEGACY/Assets/Plugins/Demigiant/DOTween/Modules/DOTweenModuleUnityVersion.cs
+++ b/UnityTests.Unity5.LEGACY/Assets/Plugins/Demigiant/DOTween/Modules/DOTweenModuleUnityVersion.cs
@@ -204,7 +204,7 @@ namespace DG.Tweening
 
         #region .NET 4.6 or Newer
 
-#if UNITY_2018_1_OR_NEWER && (NET_4_6 || NET_STANDARD_2_0)
+#if UNITY_2018_1_OR_NEWER && (NET_4_6 || NET_STANDARD_2_0) && !UNITY_WEBGL
 
         #region Async Instructions
 

--- a/UnityTests.Unity6000.3/Assets/Plugins/Demigiant/DOTween/Modules/DOTweenModuleUnityVersion.cs
+++ b/UnityTests.Unity6000.3/Assets/Plugins/Demigiant/DOTween/Modules/DOTweenModuleUnityVersion.cs
@@ -204,7 +204,7 @@ namespace DG.Tweening
 
         #region .NET 4.6 or Newer
 
-#if UNITY_2018_1_OR_NEWER && (NET_4_6 || NET_STANDARD_2_0)
+#if UNITY_2018_1_OR_NEWER && (NET_4_6 || NET_STANDARD_2_0) && !UNITY_WEBGL
 
         #region Async Instructions
 

--- a/_DOTween.Assembly/bin/Modules/DOTweenModuleUnityVersion.cs
+++ b/_DOTween.Assembly/bin/Modules/DOTweenModuleUnityVersion.cs
@@ -204,7 +204,7 @@ namespace DG.Tweening
 
         #region .NET 4.6 or Newer
 
-#if UNITY_2018_1_OR_NEWER && (NET_4_6 || NET_STANDARD_2_0)
+#if UNITY_2018_1_OR_NEWER && (NET_4_6 || NET_STANDARD_2_0) && !UNITY_WEBGL
 
         #region Async Instructions
 


### PR DESCRIPTION
**Context / Problem**
DOTween exposes async/Task-based instructions when targeting .NET 4.6+ / .NET Standard 2.0.
On WebGL, `Task`-based async APIs are not supported in a meaningful or safe way due to the single-threaded execution model and lack of real threading. This leads to silent hangs or undefined behavior rather than explicit failures.

**What was changed**

* Excluded DOTween async instructions from compilation on `UNITY_WEBGL`.
* Added `!UNITY_WEBGL` to the existing preprocessor guards for async-related code paths.
* Applied consistently across:

  * UnityExamples
  * UnityTests (multiple Unity versions)
  * Prebuilt DOTween assembly sources

**Why this approach**

* Enforces correctness at **compile time**, not runtime.
* Prevents accidental usage of unsupported async APIs on WebGL.
* Aligns with WebGL platform constraints and avoids silent runtime failures.

**Impact**

* No behavior change for non-WebGL platforms.
* On WebGL, async/Task-based DOTween APIs are no longer available, making platform limitations explicit.

**Risk**
Low. Change is limited to conditional compilation and does not affect runtime logic on supported platforms.
